### PR TITLE
fix(Package_): fix computed order

### DIFF
--- a/src/Package_Action.php
+++ b/src/Package_Action.php
@@ -144,7 +144,7 @@ class Package_Action extends CommonDBTM
     public function prepareInputForAdd($input)
     {
         $input = $this->prepareJsonInput($input);
-        $input["order"] = $input['order'] ?? $this->getNextOrder($input['plugin_deploy_packages_id']);
+        $input["order"] = $input['order'] ?? $this->getNextOrder((int) $input['plugin_deploy_packages_id']);
 
         return $input;
     }

--- a/src/Package_Check.php
+++ b/src/Package_Check.php
@@ -259,7 +259,7 @@ class Package_Check extends CommonDBTM
 
     public function prepareInputForAdd($input)
     {
-        $input["order"] = $input['order'] ?? $this->getNextOrder($input['plugin_deploy_packages_id']);
+        $input["order"] = $input['order'] ?? $this->getNextOrder((int) $input['plugin_deploy_packages_id']);
 
         return $input;
     }

--- a/src/Package_File.php
+++ b/src/Package_File.php
@@ -89,7 +89,7 @@ class Package_File extends CommonDBTM
             return false;
         }
 
-        $input["order"] = $input['order'] ?? $this->getNextOrder($input['plugin_deploy_packages_id']);
+        $input["order"] = $input['order'] ?? $this->getNextOrder((int) $input['plugin_deploy_packages_id']);
 
         return $input;
     }

--- a/src/Package_Subitem.php
+++ b/src/Package_Subitem.php
@@ -121,7 +121,7 @@ trait Package_Subitem
     }
 
 
-    public function getNextOrder($packages_id)
+    public function getNextOrder(int $packages_id)
     {
         global $DB;
 

--- a/src/Package_UserInteraction.php
+++ b/src/Package_UserInteraction.php
@@ -138,7 +138,7 @@ class Package_UserInteraction extends CommonDBTM
 
     public function prepareInputForAdd($input)
     {
-        $input["order"] = $input['order'] ?? $this->getNextOrder($input['plugin_deploy_packages_id']);
+        $input["order"] = $input['order'] ?? $this->getNextOrder((int) $input['plugin_deploy_packages_id']);
 
         return $input;
     }


### PR DESCRIPTION
Prevent warning about missing key

```shell
[2023-01-20 09:49:40] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "plugin_deploy_packages_id" in /home/stanislas/TECLIB/DEV/GLPI/10.0-bugfixes/plugins/deploy/src/Package_Subitem.php at line 133
  Backtrace :
  plugins/deploy/src/Package_File.php:92             GlpiPlugin\Deploy\Package_File->getNextOrder()
  src/CommonDBTM.php:1281                            GlpiPlugin\Deploy\Package_File->prepareInputForAdd()
  plugins/deploy/front/package.form.php:74           CommonDBTM->add()
  
[2023-01-20 09:49:40] glpiphplog.WARNING:   *** PHP Warning (2): Undefined array key "order" in /home/stanislas/TECLIB/DEV/GLPI/10.0-bugfixes/plugins/deploy/src/Package_Subitem.php at line 138
  Backtrace :
  plugins/deploy/src/Package_File.php:92             GlpiPlugin\Deploy\Package_File->getNextOrder()
  src/CommonDBTM.php:1281                            GlpiPlugin\Deploy\Package_File->prepareInputForAdd()
  plugins/deploy/front/package.form.php:74           CommonDBTM->add()
```
```Undefined array key "order"```  because an alias is missing in the SQL query

```Undefined array key "plugin_deploy_packages_id```  because ```$this->fields['plugin_deploy_packages_id']``` can't be set at this location.
