### PR TITLE
fix(Core): move Computer Group to sub namespace

### DIFF
--- a/front/computer/group.form.php
+++ b/front/computer/group.form.php
@@ -28,13 +28,13 @@
  * -------------------------------------------------------------------------
  */
 
- namespace GlpiPlugin\Deploy;
+ namespace GlpiPlugin\Deploy\Computer;
 
 use Glpi\Event;
 use Html;
 use Session;
 
-include ('../../../inc/includes.php');
+include ('../../../../inc/includes.php');
 
 Session::checkRight("computer_group", READ);
 
@@ -46,15 +46,15 @@ if (!isset($_GET["withtemplate"])) {
    $_GET["withtemplate"] = "";
 }
 
-$computergroup = new Computer_Group();
-$computergroupstatic = new Computer_Group_Static();
-$computergroup_dynamic = new Computer_Group_Dynamic();
+$computergroup = new Group();
+$computergroupstatic = new Group_Static();
+$computergroup_dynamic = new Group_Dynamic();
 
 //Add a new computergroup
 if (isset($_POST["add"])) {
    $computergroup->check(-1, CREATE, $_POST);
    if ($newID = $computergroup->add($_POST)) {
-      Event::log($newID, "Computer_Group", 4, "inventory",
+      Event::log($newID, "Group", 4, "inventory",
                  sprintf(__('%1$s adds the item %2$s'), $_SESSION["glpiname"], $_POST["name"]));
 
       if ($_SESSION['glpibackcreated']) {
@@ -125,7 +125,7 @@ if (isset($_POST["add"])) {
 
 
    Html::header(
-      Computer_Group::getTypeName(Session::getPluralNumber()),
+      Group::getTypeName(Session::getPluralNumber()),
       '',
       'tools',
       'glpiplugin\deploy\menu',

--- a/front/computer/group.php
+++ b/front/computer/group.php
@@ -29,24 +29,24 @@
  */
 
 
-namespace GlpiPlugin\Deploy;
+namespace GlpiPlugin\Deploy\Computer;
 
 use Html;
 use Search;
 use Session;
 
-include ('../../../inc/includes.php');
+include ('../../../../inc/includes.php');
 
 Session::checkRight("computer_group", UPDATE);
 
 Html::header(
-    Computer_Group::getTypeName(Session::getPluralNumber()),
+    Group::getTypeName(Session::getPluralNumber()),
     '',
     'tools',
     'glpiplugin\deploy\menu',
     'computer_group'
 );
 
-Search::show('GlpiPlugin\Deploy\Computer_Group');
+Search::show('GlpiPlugin\Deploy\Computer\Group');
 
 Html::footer();

--- a/hook.php
+++ b/hook.php
@@ -1,5 +1,16 @@
 <?php
 
+use GlpiPlugin\Deploy\Computer\Group;
+use GlpiPlugin\Deploy\Computer\Group_Dynamic;
+use GlpiPlugin\Deploy\Computer\Group_Static;
+use GlpiPlugin\Deploy\Package;
+use GlpiPlugin\Deploy\Package_Action;
+use GlpiPlugin\Deploy\Package_Check;
+use GlpiPlugin\Deploy\Package_File;
+use GlpiPlugin\Deploy\Package_Target;
+use GlpiPlugin\Deploy\Profile;
+use GlpiPlugin\Deploy\Repository;
+
 /**
  * -------------------------------------------------------------------------
  * Deploy plugin for GLPI
@@ -33,19 +44,16 @@ function plugin_deploy_install()
     $version   = plugin_version_deploy();
     $migration = new Migration($version['version']);
 
-    // Parse src directory
-    foreach (glob(dirname(__FILE__) . '/src/*') as $filepath) {
-        // Load *.class.php files and get the class name
-        if (preg_match("/src\/(.+).php$/", $filepath, $matches)) {
-            $classname = 'GlpiPlugin\\Deploy\\' . ucfirst($matches[1]);
-            $refl = new ReflectionClass($classname);
-            // If the install method exists, load it
-            if (method_exists($classname, 'install') && !$refl->isTrait()) {
-                $classname::install($migration);
-            }
-        }
-    }
-    $migration->executeMigration();
+    Package_Action::install($migration);
+    Package_Check::install($migration);
+    Package_File::install($migration);
+    Package::install($migration);
+    Package_Target::install($migration);
+    Profile::install($migration);
+    Repository::install($migration);
+    Group::install($migration);
+    Group_Dynamic::install($migration);
+    Group_Static::install($migration);
 
     return true;
 }
@@ -59,18 +67,14 @@ function plugin_deploy_uninstall()
 {
     $migration = new Migration(PLUGIN_DEPLOY_VERSION);
 
-    // Parse src directory
-    foreach (glob(dirname(__FILE__) . '/src/*') as $filepath) {
-        // Load *.class.php files and get the class name
-        if (preg_match("/src\/(.+).php/", $filepath, $matches)) {
-            $classname = 'GlpiPlugin\\Deploy\\' . ucfirst($matches[1]);
-            $refl = new ReflectionClass($classname);
-            // If the install method exists, load it
-            if (method_exists($classname, 'uninstall') && !$refl->isTrait()) {
-                $classname::uninstall($migration);
-            }
-        }
-    }
+    Package_Target::uninstall($migration);
+    Package::uninstall($migration);
+    Profile::uninstall($migration);
+    Repository::uninstall($migration);
+    Group::uninstall($migration);
+    Group_Dynamic::uninstall($migration);
+    Group_Static::uninstall($migration);
+
     return true;
 }
 

--- a/src/Computer/Group.php
+++ b/src/Computer/Group.php
@@ -28,18 +28,17 @@
  * -------------------------------------------------------------------------
  */
 
-namespace GlpiPlugin\Deploy;
+ namespace GlpiPlugin\Deploy\Computer;
 
 use CommonDBTM;
 use Computer;
 use DisplayPreference;
 use Glpi\Application\View\TemplateRenderer;
-use Html;
 use Migration;
 use Search;
 use Session;
 
-class Computer_Group extends CommonDBTM
+class Group extends CommonDBTM
 {
 
    public    $dohistory  = true;
@@ -61,8 +60,8 @@ class Computer_Group extends CommonDBTM
    function defineTabs($options = []) {
       $ong = [];
       $this->addDefaultFormTab($ong)
-         ->addStandardTab('GlpiPlugin\Deploy\Computer_Group_Dynamic', $ong, $options)
-         ->addStandardTab('GlpiPlugin\Deploy\Computer_Group_Static', $ong, $options)
+         ->addStandardTab('GlpiPlugin\Deploy\Computer\Group_Dynamic', $ong, $options)
+         ->addStandardTab('GlpiPlugin\Deploy\Computer\Group_Static', $ong, $options)
          ->addStandardTab('Log', $ong, $options);
       return $ong;
    }
@@ -89,7 +88,7 @@ class Computer_Group extends CommonDBTM
 
       $tab[] = [
          'id'               => '5',
-         'table'            => Computer_Group_Dynamic::getTable(),
+         'table'            => Group_Dynamic::getTable(),
          'field'            => 'search',
          'name'             => __('Number of dynamics items', 'deploy'),
          'nosearch'         => true,
@@ -102,7 +101,7 @@ class Computer_Group extends CommonDBTM
 
       $tab[] = [
          'id'                 => '6',
-         'table'              => Computer_Group_Static::getTable(),
+         'table'              => Group_Static::getTable(),
          'field'              => 'id',
          'name'               => __('Number of statics items', 'deploy'),
          'forcegroupby'       => true,
@@ -115,7 +114,7 @@ class Computer_Group extends CommonDBTM
 
       $tab[] = [
          'id'               => '7',
-         'table'            => Computer_Group_Dynamic::getTable(),
+         'table'            => Group_Dynamic::getTable(),
          'field'            => '_virtual_dynamic_list',
          'name'             => __('List of dynamics items', 'deploy'),
          'massiveaction'    => false,
@@ -137,7 +136,7 @@ class Computer_Group extends CommonDBTM
          'massiveaction'      => false,
          'joinparams'         => [
             'beforejoin'         => [
-               'table'              => Computer_Group_Static::getTable(),
+               'table'              => Group_Static::getTable(),
                'joinparams'         => [
                   'jointype'           => 'child',
                ]
@@ -171,7 +170,7 @@ class Computer_Group extends CommonDBTM
 
       $params = [
          'SELECT' => '*',
-         'FROM'   => Computer_Group_Dynamic::getTable(),
+         'FROM'   => Group_Dynamic::getTable(),
          'WHERE'  => ['plugin_deploy_computers_groups_id' => $this->fields['id']],
       ];
 
@@ -196,7 +195,7 @@ class Computer_Group extends CommonDBTM
 
       $params = [
          'SELECT' => '*',
-         'FROM'   => Computer_Group_Static::getTable(),
+         'FROM'   => Group_Static::getTable(),
          'WHERE'  => ['plugin_deploy_computers_groups_id' => $this->fields['id']],
       ];
 
@@ -256,7 +255,7 @@ class Computer_Group extends CommonDBTM
       $migration->displayMessage("Uninstalling $table");
       $migration->dropTable($table);
 
-      $DB->doQuery("DELETE FROM `glpi_displaypreferences` WHERE `itemtype` = 'GlpiPlugin\\\Deploy\\\Computer_Group'");
+      $DB->doQuery("DELETE FROM `glpi_displaypreferences` WHERE `itemtype` = 'GlpiPlugin\\\Deploy\\\Computer\\\Group'");
    }
 
 

--- a/src/Computer/Group_Dynamic.php
+++ b/src/Computer/Group_Dynamic.php
@@ -28,7 +28,7 @@
  * -------------------------------------------------------------------------
  */
 
-namespace GlpiPlugin\Deploy;
+namespace GlpiPlugin\Deploy\Computer;
 
 use CommonDBTM;
 use CommonGLPI;
@@ -40,7 +40,7 @@ use Search;
 use Session;
 use Toolbox;
 
-class Computer_Group_Dynamic extends CommonDBTM
+class Group_Dynamic extends CommonDBTM
 {
    static    $rightname  = 'computer_group';
 
@@ -61,7 +61,7 @@ class Computer_Group_Dynamic extends CommonDBTM
 
    function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
 
-      if (get_class($item) == Computer_Group::getType()) {
+      if (get_class($item) == Group::getType()) {
          $count = 0;
          $computergroup_dynamic = new self();
          if ($computergroup_dynamic->getFromDBByCrit([
@@ -81,14 +81,16 @@ class Computer_Group_Dynamic extends CommonDBTM
       if (!is_array($values)) {
          $values = [$field => $values];
       }
+      Toolbox::logDebug($field);
       switch ($field) {
          case 'search' :
             $count = 0;
             if (strpos($values['id'], Search::NULLVALUE) === false ) {
-               $computergroup_dynamic = new Computer_Group_Dynamic();
+               $computergroup_dynamic = new Group_Dynamic();
                $computergroup_dynamic->getFromDB($values['id']);
                $count = $computergroup_dynamic->countDynamicItems();
             }
+            Toolbox::logDebug($count);
             return  ($count) ? $count : ' 0 ';
 
          case '_virtual_dynamic_list' :
@@ -191,7 +193,7 @@ class Computer_Group_Dynamic extends CommonDBTM
    }
 
 
-   static function showForItem(Computer_Group $computergroup) {
+   static function showForItem(Group $computergroup) {
 
       $ID = $computergroup->getField('id');
       if (!$computergroup->can($ID, UPDATE)) {
@@ -221,7 +223,7 @@ class Computer_Group_Dynamic extends CommonDBTM
          }
 
          //redirect to computergroup dynamic tab after saved search
-         $target = Computer_Group::getFormURLWithID($ID);
+         $target = Group::getFormURLWithID($ID);
          $target .= "&_glpi_tab=Computer_Group_Dynamic$1";
          $p['target'] = $target;
          $p['addhidden'] = [

--- a/src/Computer/Group_Static.php
+++ b/src/Computer/Group_Static.php
@@ -28,7 +28,7 @@
  * -------------------------------------------------------------------------
  */
 
-namespace GlpiPlugin\Deploy;
+ namespace GlpiPlugin\Deploy\Computer;
 
 use CommonDBRelation;
 use CommonGLPI;
@@ -42,11 +42,11 @@ use Search;
 use Session;
 use Toolbox;
 
-class Computer_Group_Static extends CommonDBRelation
+class Group_Static extends CommonDBRelation
 {
 
    // From CommonDBRelation
-   static public $itemtype_1 = 'GlpiPlugin\Deploy\Computer_Group';
+   static public $itemtype_1 = 'GlpiPlugin\Deploy\Computer\Group';
    static public $items_id_1 = 'plugin_deploy_computers_groups_id';
    static public $itemtype_2 = 'Computer';
    static public $items_id_2 = 'computers_id';
@@ -80,7 +80,7 @@ class Computer_Group_Static extends CommonDBRelation
 
 
    function getTabNameForItem(CommonGLPI $item, $withtemplate = 0) {
-      if (get_class($item) == Computer_Group::getType()) {
+      if (get_class($item) == Group::getType()) {
          $count = 0;
          $count = countElementsInTable(self::getTable(), ['plugin_deploy_computers_groups_id' => $item->getID()]);
          $ong = [];
@@ -113,7 +113,7 @@ class Computer_Group_Static extends CommonDBRelation
    }
 
 
-   static function showForItem(Computer_Group $computergroup)
+   static function showForItem(Group $computergroup)
    {
       global $DB;
 
@@ -138,7 +138,7 @@ class Computer_Group_Static extends CommonDBRelation
 
       if ($computergroup->canAddItem('itemtype')) {
          TemplateRenderer::getInstance()->display('@deploy/computer_group/computer_group_static.html.twig', [
-            'form_action'  => Toolbox::getItemTypeFormURL("GlpiPlugin\Deploy\Computer_Group"),
+            'form_action'  => Toolbox::getItemTypeFormURL("GlpiPlugin\Deploy\Computer\Group"),
             'computers_groups_id' => $ID,
             'computer_used' => $used,
             'params'       => [],

--- a/src/Computer_Group.php
+++ b/src/Computer_Group.php
@@ -38,7 +38,6 @@ use Html;
 use Migration;
 use Search;
 use Session;
-use Toolbox;
 
 class Computer_Group extends CommonDBTM
 {

--- a/src/Menu.php
+++ b/src/Menu.php
@@ -30,6 +30,7 @@
 
 namespace GlpiPlugin\Deploy;
 
+use GlpiPlugin\Deploy\Computer\Group;
 use \Session;
 
 class Menu
@@ -55,8 +56,8 @@ class Menu
                 Package::class,
             ];
 
-            if (Computer_Group::canCreate()) {
-                $links_class[] = Computer_Group::class;
+            if (Group::canCreate()) {
+                $links_class[] = Group::class;
             }
 
             $links = [];
@@ -86,17 +87,17 @@ class Menu
                 $menu['options']['package']['links']['add'] = $add_link;
             }
 
-            if (Computer_Group::canCreate()) {
+            if (Group::canCreate()) {
                 $menu['options']['computer_group'] = [
-                    'title' => Computer_Group::getTypeName(Session::getPluralNumber()),
-                    'page'  => Computer_Group::getSearchURL(false),
-                    'icon'  => Computer_Group::getIcon(),
+                    'title' => Group::getTypeName(Session::getPluralNumber()),
+                    'page'  => Group::getSearchURL(false),
+                    'icon'  => Group::getIcon(),
                     'links' => $links,
                 ];
 
-                $add_link = Computer_Group::getFormURL(false);
-                $menu['options']['computer_group']['options']['add'] = Computer_Group::getFormURL(false);
-                $menu['options']['computer_group']['links']['add']   = Computer_Group::getFormURL(false);
+                $add_link = Group::getFormURL(false);
+                $menu['options']['computer_group']['options']['add'] = Group::getFormURL(false);
+                $menu['options']['computer_group']['links']['add']   = Group::getFormURL(false);
             }
 
         }

--- a/src/Package_Target.php
+++ b/src/Package_Target.php
@@ -34,6 +34,7 @@ use CommonDBRelation;
 use CommonGLPI;
 use DBConnection;
 use Glpi\Application\View\TemplateRenderer;
+use GlpiPlugin\Deploy\Computer\Group;
 use Migration;
 use Session;
 
@@ -42,7 +43,7 @@ class Package_Target extends CommonDBRelation
     public static $itemtype_1 = Package::class;
     public static $items_id_1 = "plugin_deploy_packages_id";
 
-    public static $itemtype_2 = Computer_Group::class;
+    public static $itemtype_2 = Group::class;
     public static $items_id_2 = "plugin_deploy_computers_groups_id";
 
     static public $checkItem_2_Rights  = self::DONT_CHECK_ITEM_RIGHTS;
@@ -60,14 +61,6 @@ class Package_Target extends CommonDBRelation
     public static function getIcon()
     {
         return "ti ti-devices-pc";
-    }
-
-
-    public static function getItemtypes(): array
-    {
-        return [
-            Computer_Group::class,
-        ];
     }
 
 
@@ -109,7 +102,7 @@ class Package_Target extends CommonDBRelation
         $targets = [];
         $used = [];
         foreach ($iterator as $target) {
-            $item = new Computer_Group();
+            $item = new Group();
             $item->getFromDB($target['plugin_deploy_computers_groups_id']);
             $targets[$target['id']] = $item;
             $used[$target['plugin_deploy_computers_groups_id']] = $target['plugin_deploy_computers_groups_id'];
@@ -138,7 +131,7 @@ class Package_Target extends CommonDBRelation
             $sign              = DBConnection::getDefaultPrimaryKeySignOption();
 
             $package_fk = getForeignKeyFieldForItemType(Package::class);
-            $computer_group_fk = getForeignKeyFieldForItemType(Computer_Group::class);
+            $computer_group_fk = getForeignKeyFieldForItemType(Group::class);
 
             $query = "CREATE TABLE IF NOT EXISTS `$table` (
                 `id` int $sign NOT NULL AUTO_INCREMENT,

--- a/src/Profile.php
+++ b/src/Profile.php
@@ -32,6 +32,7 @@ namespace GlpiPlugin\Deploy;
 
 use CommonGLPI;
 use DbUtils;
+use GlpiPlugin\Deploy\Computer\Group;
 use Html;
 use Migration;
 use Profile as GlobalProfile;
@@ -48,8 +49,8 @@ class Profile extends GlobalProfile {
 
    static function getAllRights($all = false) {
       $rights = [
-         ['itemtype' => Computer_Group::getType(),
-               'label'    => Computer_Group::getTypeName(),
+         ['itemtype' => Group::getType(),
+               'label'    => Group::getTypeName(),
                'field'    => 'computer_group'
          ]
       ];

--- a/templates/computer_group/computer_group_static.html.twig
+++ b/templates/computer_group/computer_group_static.html.twig
@@ -28,7 +28,7 @@
 
 {% import 'components/form/fields_macros.html.twig' as fields %}
 
-<form method='POST' enctype='multipart/form-data' action='{{  call('Toolbox::getItemTypeFormURL("GlpiPlugin\Deploy\Computer_Group")')   }}'>
+<form method='POST' enctype='multipart/form-data' action='{{  call('Toolbox::getItemTypeFormURL("GlpiPlugin\Deploy\Computer\Group")')   }}'>
    <div class="d-flex">
       {{ fields.dropdownField(
          'Computer',

--- a/templates/package/target.list.html.twig
+++ b/templates/package/target.list.html.twig
@@ -32,10 +32,10 @@
 
 {% block subitem_form %}
     {{ fields.dropdownField(
-        "GlpiPlugin\\Deploy\\Computer_Group",
+        "GlpiPlugin\\Deploy\\Computer\\Group",
         'plugin_deploy_computers_groups_id',
         '0',
-        call('GlpiPlugin\\Deploy\\Computer_Group::getTypeName', [0]),
+        call('GlpiPlugin\\Deploy\\Computer\\Group::getTypeName', [0]),
         {
             'used': used_item,
         }


### PR DESCRIPTION
To prevent  ```GLPIplugin/Deploy/Computer_Group_Dynamic``` class name not understand by ```GLPI``` (two underscore)

Move related file / call to ```GLPIplugin/Deploy/Computer/Group_Dynamic```